### PR TITLE
Removed "appli_name" key from "vsurface" in example/initial-vscreen/*/initial-vscreen.json

### DIFF
--- a/example/initial-vscreen/global/initial-vscreen.json
+++ b/example/initial-vscreen/global/initial-vscreen.json
@@ -17,7 +17,6 @@
       "vdst_h": 1080,
       "vsurface": [
         {
-          "appli_name": "wayland-app",
           "VID": 5100,
           "pixel_w": 400,
           "pixel_h": 240,

--- a/example/initial-vscreen/vdisplay/initial-vscreen.json
+++ b/example/initial-vscreen/vdisplay/initial-vscreen.json
@@ -18,7 +18,6 @@
       "vdst_h": 540,
       "vsurface": [
         {
-          "appli_name": "wayland-app",
           "VID": 5100,
           "pixel_w": 400,
           "pixel_h": 240,

--- a/internal/ula-client/ulacommgen/ula_comm_generator.go
+++ b/internal/ula-client/ulacommgen/ula_comm_generator.go
@@ -24,11 +24,11 @@ import (
 	. "ula-tools/internal/ulog"
 )
 
-func convCAVSurface2UPIVsurface(csurf *core.CAVsurface) *UPIVsurface {
+func convCAVSurface2UPIVsurface(csurf *core.CAVsurface, appName string) *UPIVsurface {
 
 	usurf := new(UPIVsurface)
 
-	usurf.AppName = csurf.AppName
+	usurf.AppName = appName
 
 	usurf.VID = csurf.VID
 
@@ -77,7 +77,7 @@ func convCAVlayer2UPIVlayer(clayer *core.CAVlayer) *UPIVlayer {
 	ulayer.Surface = make([]UPIVsurface, 0)
 
 	for _, cVsurf := range clayer.Vsurfaces {
-		usurf := convCAVSurface2UPIVsurface(&cVsurf)
+		usurf := convCAVSurface2UPIVsurface(&cVsurf, ulayer.AppName)
 		ulayer.Surface = append(ulayer.Surface, *usurf)
 	}
 
@@ -98,10 +98,10 @@ func convCAVLayoutTree2UPIVscreen(ctree *core.CALayoutTree) *UPIVscreen {
 	return uscreen
 }
 
-func convVirtualSurface2UPIVsurface(vsurf *ula.VirtualSurface) *UPIVsurface {
+func convVirtualSurface2UPIVsurface(vsurf *ula.VirtualSurface, appName string) *UPIVsurface {
 	usurf := new(UPIVsurface)
 
-	usurf.AppName = vsurf.AppName
+	usurf.AppName = appName
 
 	usurf.VID = vsurf.VID
 

--- a/internal/ula-node/ula_parser.go
+++ b/internal/ula-node/ula_parser.go
@@ -105,12 +105,7 @@ func getCoordFromJsonDef(mJson map[string]interface{}, key string, defval ula.Co
 	return defval, nil
 }
 
-func generateSurfaceFromParam(layerId int, mSurface map[string]interface{}) (*ula.VirtualSurface, error) {
-
-	appli_name, err := getStringFromJson(mSurface, "appli_name")
-	if err != nil {
-		return nil, err
-	}
+func generateSurfaceFromParam(layerId int, mSurface map[string]interface{}, appli_name string) (*ula.VirtualSurface, error) {
 
 	surfaceId, err := getIntFromJson(mSurface, "VID")
 	if err != nil {
@@ -381,7 +376,7 @@ func generateLayerFromParam(mLayer map[string]interface{}, genSurfaces bool, exi
 		}
 
 		for _, mSurface := range surfaces {
-			newVsurface, err := generateSurfaceFromParam(layerId, mSurface.(map[string]interface{}))
+			newVsurface, err := generateSurfaceFromParam(layerId, mSurface.(map[string]interface{}), appli_name)
 			if err != nil {
 				ELog.Println("error in generateLayerFromParam")
 				return nil, err


### PR DESCRIPTION
To make it easier to understand the "initial_vscreen.json" file more intuitively, I deleted the "appli_name" key, which was originally included for generating commands internally, from the "vsurface."